### PR TITLE
add LDAP authentication support for login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,25 @@ TOKEN_ROTATION_INTERVAL_MINUTES=10
 # Server
 PORT=3001
 LOG_LEVEL=debug
+
+# LDAP Authentication
+# Set to true to enable LDAP authentication. When enabled, LDAP is tried first with fallback to local auth.
+LDAP_ENABLED=false
+LDAP_HOST=
+LDAP_PORT=389
+# Service account used to search for users
+LDAP_BIND_DN=cn=admin,dc=example,dc=com
+LDAP_BIND_PASSWORD=
+# Base DN for user searches
+LDAP_BASE_DN=dc=example,dc=com
+# Search filter. %s is replaced with the login input (escaped).
+LDAP_SEARCH_FILTER=(|(uid=%s)(mail=%s))
+# LDAP attribute mappings
+LDAP_USERNAME_ATTRIBUTE=uid
+LDAP_EMAIL_ATTRIBUTE=mail
+LDAP_NAME_ATTRIBUTE=cn
+# TLS settings
+LDAP_START_TLS=false
+LDAP_SKIP_TLS_VERIFY=false
+# Auto-create local accounts for LDAP users on first login
+LDAP_AUTO_PROVISION=true

--- a/cmd/monolith/main.go
+++ b/cmd/monolith/main.go
@@ -16,6 +16,7 @@ import (
 	"monolith/internal/logger"
 	"monolith/internal/service/account"
 	"monolith/internal/service/auth"
+	"monolith/internal/service/ldap"
 	"monolith/internal/service/login"
 	"monolith/migrations"
 
@@ -41,7 +42,8 @@ func main() {
 	migrations.Up(stdlib.OpenDBFromPool(db.PgxPool()))
 
 	accountService := account.NewService(db)
-	loginService := login.NewService(db, accountService)
+	ldapService := ldap.NewService(cfg.LDAP)
+	loginService := login.NewService(db, accountService, ldapService)
 	authService := auth.NewService(db, cfg.Security)
 
 	srv := api.NewHTTPServer(db, cfg, accountService, loginService, authService)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.3
 
 require (
 	github.com/georgysavva/scany/v2 v2.1.4
+	github.com/go-ldap/ldap/v3 v3.4.10
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0

--- a/internal/api/account_test.go
+++ b/internal/api/account_test.go
@@ -48,11 +48,11 @@ func TestAccountHandler_Profile(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE id = \$1 AND status = 'active'`).
 					WithArgs(accountID).
@@ -234,11 +234,11 @@ func TestAccountHandler_UpdatePreferences(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					false, stringPtr("fr"), stringPtr("dark"),
-					stringPtr("Europe/Paris"), nil, "active", now, now,
+					stringPtr("Europe/Paris"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`UPDATE account SET language = \$1, theme = \$2, timezone = \$3, updated_at = NOW\(\) WHERE id = \$4 AND status = 'active' RETURNING`).
 					WithArgs(stringPtr("fr"), stringPtr("dark"), stringPtr("Europe/Paris"), accountID).

--- a/internal/api/login_test.go
+++ b/internal/api/login_test.go
@@ -60,11 +60,11 @@ func TestAuthHandler_Login(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				accountRows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -97,11 +97,11 @@ func TestAuthHandler_Login(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				accountRows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -142,7 +142,7 @@ func TestAuthHandler_Login(t *testing.T) {
 
 			db := &database.DB{Pool: mock}
 			accountService := account.NewService(db)
-			loginService := login.NewService(db, accountService)
+			loginService := login.NewService(db, accountService, nil)
 			authService := auth.NewService(db, cfg)
 			handler := NewAuthHandler(loginService, authService)
 
@@ -209,7 +209,7 @@ func TestAuthHandler_Logout(t *testing.T) {
 
 			db := &database.DB{Pool: mock}
 			accountService := account.NewService(db)
-			loginService := login.NewService(db, accountService)
+			loginService := login.NewService(db, accountService, nil)
 			authService := auth.NewService(db, cfg)
 			handler := NewAuthHandler(loginService, authService)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,23 @@ type Config struct {
 	Database DatabaseConfig
 	Server   ServerConfig
 	Logging  LoggingConfig
+	LDAP     LDAPConfig
+}
+
+type LDAPConfig struct {
+	Enabled           bool
+	Host              string
+	Port              int
+	BindDN            string
+	BindPassword      string
+	BaseDN            string
+	SearchFilter      string
+	UsernameAttribute string
+	EmailAttribute    string
+	NameAttribute     string
+	StartTLS          bool
+	SkipTLSVerify     bool
+	AutoProvision     bool
 }
 
 type SecurityConfig struct {
@@ -44,6 +61,11 @@ const (
 	defaultDatabaseURL                  = "postgres://postgres:postgres@localhost:5432/my_db"
 	defaultPort                         = "3001"
 	defaultLogLevel                     = slog.LevelInfo
+	defaultLDAPPort                     = 389
+	defaultLDAPSearchFilter             = "(|(uid=%s)(mail=%s))"
+	defaultLDAPUsernameAttribute        = "uid"
+	defaultLDAPEmailAttribute           = "mail"
+	defaultLDAPNameAttribute            = "cn"
 )
 
 func NewConfig() *Config {
@@ -65,6 +87,21 @@ func NewConfig() *Config {
 		},
 		Logging: LoggingConfig{
 			Level: parseLogLevelOrDefault("LOG_LEVEL", defaultLogLevel),
+		},
+		LDAP: LDAPConfig{
+			Enabled:           parseBoolOrDefault("LDAP_ENABLED", false),
+			Host:              getEnvOrDefault("LDAP_HOST", ""),
+			Port:              parseIntOrDefault("LDAP_PORT", defaultLDAPPort),
+			BindDN:            getEnvOrDefault("LDAP_BIND_DN", ""),
+			BindPassword:      getEnvOrDefault("LDAP_BIND_PASSWORD", ""),
+			BaseDN:            getEnvOrDefault("LDAP_BASE_DN", ""),
+			SearchFilter:      getEnvOrDefault("LDAP_SEARCH_FILTER", defaultLDAPSearchFilter),
+			UsernameAttribute: getEnvOrDefault("LDAP_USERNAME_ATTRIBUTE", defaultLDAPUsernameAttribute),
+			EmailAttribute:    getEnvOrDefault("LDAP_EMAIL_ATTRIBUTE", defaultLDAPEmailAttribute),
+			NameAttribute:     getEnvOrDefault("LDAP_NAME_ATTRIBUTE", defaultLDAPNameAttribute),
+			StartTLS:          parseBoolOrDefault("LDAP_START_TLS", false),
+			SkipTLSVerify:     parseBoolOrDefault("LDAP_SKIP_TLS_VERIFY", false),
+			AutoProvision:     parseBoolOrDefault("LDAP_AUTO_PROVISION", true),
 		},
 	}
 }
@@ -94,6 +131,15 @@ func parseIntOrDefault(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {
 		if intValue, err := strconv.Atoi(value); err == nil {
 			return intValue
+		}
+	}
+	return defaultValue
+}
+
+func parseBoolOrDefault(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		if boolValue, err := strconv.ParseBool(value); err == nil {
+			return boolValue
 		}
 	}
 	return defaultValue

--- a/internal/service/account/account.go
+++ b/internal/service/account/account.go
@@ -68,7 +68,7 @@ func (s *Service) Register(ctx context.Context, req RegisterRequest) (*Account, 
 		INSERT INTO account (username, email, name, password, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, NOW(), NOW())
 		RETURNING id, username, email, name, is_admin, language, theme, timezone,
-		          last_seen_at, status, created_at, updated_at
+		          last_seen_at, status, auth_source, created_at, updated_at
 	`, req.Username, req.Email, req.Name, hashedPassword)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (s *Service) GetAccountByLogin(ctx context.Context, login string) (*Account
 	var account Account
 	err := pgxscan.Get(ctx, s.db.Pool, &account, `
 		SELECT id, username, email, name, password, is_admin, language, theme, timezone,
-		       last_seen_at, status, created_at, updated_at
+		       last_seen_at, status, auth_source, created_at, updated_at
 		FROM account
 		WHERE (email = $1 OR username = $1) AND status = 'active'
 	`, login)
@@ -96,11 +96,36 @@ func (s *Service) GetAccountByLogin(ctx context.Context, login string) (*Account
 	return &account, nil
 }
 
+func (s *Service) GetOrCreateLDAPAccount(ctx context.Context, username, email, name string) (*Account, error) {
+	existing, err := s.GetAccountByLogin(ctx, email)
+	if err == nil {
+		return existing, nil
+	}
+
+	existing, err = s.GetAccountByLogin(ctx, username)
+	if err == nil {
+		return existing, nil
+	}
+
+	var account Account
+	err = pgxscan.Get(ctx, s.db.Pool, &account, `
+		INSERT INTO account (username, email, name, auth_source, status, created_at, updated_at)
+		VALUES ($1, $2, $3, 'ldap', 'active', NOW(), NOW())
+		RETURNING id, username, email, name, is_admin, language, theme, timezone,
+		          last_seen_at, status, auth_source, created_at, updated_at
+	`, username, email, name)
+	if err != nil {
+		return nil, fmt.Errorf("create LDAP account: %w", err)
+	}
+
+	return &account, nil
+}
+
 func (s *Service) GetAccountByID(ctx context.Context, accountID uuid.UUID) (*Account, error) {
 	var account Account
 	err := pgxscan.Get(ctx, s.db.Pool, &account, `
 		SELECT id, username, email, name, is_admin, language, theme, timezone,
-		       last_seen_at, status, created_at, updated_at
+		       last_seen_at, status, auth_source, created_at, updated_at
 		FROM account
 		WHERE id = $1 AND status = 'active'
 	`, accountID)
@@ -128,7 +153,7 @@ func (s *Service) UpdatePreferences(
 		SET language = $1, theme = $2, timezone = $3, updated_at = NOW()
 		WHERE id = $4 AND status = 'active'
 		RETURNING id, username, email, name, is_admin, language, theme, timezone,
-		          last_seen_at, status, created_at, updated_at
+		          last_seen_at, status, auth_source, created_at, updated_at
 	`, req.Language, req.Theme, req.Timezone, accountID)
 	if err != nil {
 		return nil, err
@@ -140,7 +165,7 @@ func (s *Service) GetAccounts(ctx context.Context) ([]Account, error) {
 	var accounts []Account
 	err := pgxscan.Select(ctx, s.db.Pool, &accounts, `
 		SELECT id, username, email, name, avatar, is_admin, language, theme, timezone,
-		       last_seen_at, status, created_at, updated_at
+		       last_seen_at, status, auth_source, created_at, updated_at
 		FROM account
 		ORDER BY created_at DESC
 	`)
@@ -154,7 +179,7 @@ func (s *Service) GetAccount(ctx context.Context, id uuid.UUID) (*Account, error
 	var account Account
 	err := pgxscan.Get(ctx, s.db.Pool, &account, `
 		SELECT id, username, email, name, avatar, is_admin, language, theme, timezone,
-		       last_seen_at, status, created_at, updated_at
+		       last_seen_at, status, auth_source, created_at, updated_at
 		FROM account
 		WHERE id = $1 AND status = 'active'
 	`, id)
@@ -195,7 +220,7 @@ func (s *Service) CreateAccount(ctx context.Context, req CreateAccountRequest) (
 		INSERT INTO account (username, name, email, password, is_admin, status, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
 		RETURNING id, username, email, name, avatar, is_admin, language, theme, timezone,
-		          last_seen_at, status, created_at, updated_at
+		          last_seen_at, status, auth_source, created_at, updated_at
 	`, req.Username, req.Name, req.Email, hashedPassword, isAdmin, status)
 	if err != nil {
 		return nil, err
@@ -236,7 +261,7 @@ func (s *Service) InviteUsers(ctx context.Context, req InviteUsersRequest) (*Inv
 			INSERT INTO account (username, email, name, is_admin, status, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, 'pending', NOW(), NOW())
 			RETURNING id, username, email, name, avatar, is_admin, language, theme, timezone,
-			          last_seen_at, status, created_at, updated_at
+			          last_seen_at, status, auth_source, created_at, updated_at
 		`, username, email, username, req.IsAdmin)
 		if err != nil {
 			response.Failed = append(response.Failed, InviteUserFailure{
@@ -259,7 +284,7 @@ func (s *Service) UpdateAccount(ctx context.Context, id uuid.UUID, req UpdateAcc
 		SET username = $1, name = $2, email = $3, updated_at = NOW()
 		WHERE id = $4 AND status = 'active'
 		RETURNING id, username, email, name, avatar, is_admin, language, theme, timezone,
-		          last_seen_at, status, created_at, updated_at
+		          last_seen_at, status, auth_source, created_at, updated_at
 	`, req.Username, req.Name, req.Email, id)
 	if err != nil {
 		return nil, err

--- a/internal/service/account/account_test.go
+++ b/internal/service/account/account_test.go
@@ -215,11 +215,11 @@ func TestService_GetAccountByLogin(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					"hashedpassword", false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -239,11 +239,11 @@ func TestService_GetAccountByLogin(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					"hashedpassword", false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("testuser").
@@ -312,11 +312,11 @@ func TestService_GetAccountByID(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE id = \$1 AND status = 'active'`).
 					WithArgs(accountID).
@@ -480,11 +480,11 @@ func TestService_UpdatePreferences(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				rows := pgxmock.NewRows([]string{
 					"id", "username", "email", "name", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
+					"last_seen_at", "status", "auth_source", "created_at", "updated_at",
 				}).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					false, stringPtr("fr"), stringPtr("dark"),
-					stringPtr("Europe/Paris"), nil, "active", now, now,
+					stringPtr("Europe/Paris"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`UPDATE account SET language = \$1, theme = \$2, timezone = \$3, updated_at = NOW\(\) WHERE id = \$4 AND status = 'active' RETURNING`).
 					WithArgs(stringPtr("fr"), stringPtr("dark"), stringPtr("Europe/Paris"), accountID).

--- a/internal/service/account/types.go
+++ b/internal/service/account/types.go
@@ -19,6 +19,7 @@ type Account struct {
 	Timezone   *string    `json:"timezone"`
 	LastSeenAt *time.Time `json:"lastSeenAt"`
 	Status     string     `json:"status"`
+	AuthSource string     `json:"authSource"`
 	CreatedAt  time.Time  `json:"createdAt"`
 	UpdatedAt  time.Time  `json:"updatedAt"`
 }

--- a/internal/service/ldap/errors.go
+++ b/internal/service/ldap/errors.go
@@ -1,0 +1,8 @@
+package ldap
+
+import "errors"
+
+var (
+	ErrInvalidCredentials = errors.New("invalid LDAP credentials")
+	ErrUserNotFound       = errors.New("LDAP user not found")
+)

--- a/internal/service/ldap/ldap.go
+++ b/internal/service/ldap/ldap.go
@@ -1,0 +1,109 @@
+package ldap
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"monolith/internal/config"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+type Service struct {
+	config config.LDAPConfig
+}
+
+type LDAPUser struct {
+	Username string
+	Email    string
+	Name     string
+}
+
+func NewService(cfg config.LDAPConfig) *Service {
+	return &Service{config: cfg}
+}
+
+func (s *Service) Enabled() bool {
+	return s.config.Enabled
+}
+
+func (s *Service) AutoProvision() bool {
+	return s.config.AutoProvision
+}
+
+func (s *Service) Authenticate(login, password string) (*LDAPUser, error) {
+	conn, err := s.connect()
+	if err != nil {
+		return nil, fmt.Errorf("ldap connect: %w", err)
+	}
+	defer conn.Close()
+
+	if err := conn.Bind(s.config.BindDN, s.config.BindPassword); err != nil {
+		return nil, fmt.Errorf("ldap service bind: %w", err)
+	}
+
+	filter := strings.ReplaceAll(s.config.SearchFilter, "%s", ldapv3.EscapeFilter(login))
+	searchRequest := ldapv3.NewSearchRequest(
+		s.config.BaseDN,
+		ldapv3.ScopeWholeSubtree,
+		ldapv3.NeverDerefAliases,
+		0, 0, false,
+		filter,
+		[]string{"dn", s.config.UsernameAttribute, s.config.EmailAttribute, s.config.NameAttribute},
+		nil,
+	)
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		return nil, fmt.Errorf("ldap search: %w", err)
+	}
+
+	if len(sr.Entries) == 0 {
+		return nil, ErrUserNotFound
+	}
+
+	if len(sr.Entries) > 1 {
+		slog.Warn("LDAP search returned multiple entries, using first match", "login", login, "count", len(sr.Entries))
+	}
+
+	entry := sr.Entries[0]
+
+	if err := conn.Bind(entry.DN, password); err != nil {
+		return nil, ErrInvalidCredentials
+	}
+
+	return &LDAPUser{
+		Username: entry.GetAttributeValue(s.config.UsernameAttribute),
+		Email:    entry.GetAttributeValue(s.config.EmailAttribute),
+		Name:     entry.GetAttributeValue(s.config.NameAttribute),
+	}, nil
+}
+
+func (s *Service) connect() (*ldapv3.Conn, error) {
+	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: s.config.SkipTLSVerify, //nolint:gosec // configurable for self-signed certs
+		ServerName:         s.config.Host,
+	}
+
+	if s.config.Port == 636 {
+		return ldapv3.DialTLS("tcp", addr, tlsConfig)
+	}
+
+	conn, err := ldapv3.Dial("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.config.StartTLS {
+		if err := conn.StartTLS(tlsConfig); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("ldap StartTLS: %w", err)
+		}
+	}
+
+	return conn, nil
+}

--- a/internal/service/login/login.go
+++ b/internal/service/login/login.go
@@ -2,38 +2,83 @@ package login
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 
 	"monolith/internal/database"
 	"monolith/internal/service/account"
+	"monolith/internal/service/ldap"
 )
 
 type Service struct {
 	db             *database.DB
 	accountService *account.Service
+	ldapService    *ldap.Service
 }
 
-func NewService(db *database.DB, accountService *account.Service) *Service {
+func NewService(db *database.DB, accountService *account.Service, ldapService *ldap.Service) *Service {
 	return &Service{
 		db:             db,
 		accountService: accountService,
+		ldapService:    ldapService,
 	}
 }
 
 func (s *Service) Login(ctx context.Context, req UserLoginRequest) (*account.Account, error) {
-	account, err := s.accountService.GetAccountByLogin(ctx, req.Login)
+	if s.ldapService != nil && s.ldapService.Enabled() {
+		acc, err := s.loginLDAP(ctx, req)
+		if err == nil {
+			return acc, nil
+		}
+
+		if !errors.Is(err, ldap.ErrUserNotFound) && !errors.Is(err, ldap.ErrInvalidCredentials) {
+			slog.Error("LDAP authentication error, falling back to local", "error", err)
+		}
+	}
+
+	return s.loginLocal(ctx, req)
+}
+
+func (s *Service) loginLocal(ctx context.Context, req UserLoginRequest) (*account.Account, error) {
+	acc, err := s.accountService.GetAccountByLogin(ctx, req.Login)
 	if err != nil {
 		return nil, ErrInvalidCredentials
 	}
 
-	err = s.accountService.ValidatePassword(account.Password, req.Password)
+	err = s.accountService.ValidatePassword(acc.Password, req.Password)
 	if err != nil {
 		return nil, ErrInvalidCredentials
 	}
 
-	err = s.accountService.UpdateLastSeen(ctx, account.ID)
+	err = s.accountService.UpdateLastSeen(ctx, acc.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return account, nil
+	return acc, nil
+}
+
+func (s *Service) loginLDAP(ctx context.Context, req UserLoginRequest) (*account.Account, error) {
+	ldapUser, err := s.ldapService.Authenticate(req.Login, req.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.ldapService.AutoProvision() {
+		acc, provisionErr := s.accountService.GetOrCreateLDAPAccount(ctx, ldapUser.Username, ldapUser.Email, ldapUser.Name)
+		if provisionErr != nil {
+			return nil, provisionErr
+		}
+
+		_ = s.accountService.UpdateLastSeen(ctx, acc.ID)
+		return acc, nil
+	}
+
+	acc, err := s.accountService.GetAccountByLogin(ctx, req.Login)
+	if err != nil {
+		return nil, ErrInvalidCredentials
+	}
+
+	_ = s.accountService.UpdateLastSeen(ctx, acc.ID)
+	return acc, nil
 }

--- a/internal/service/login/login_test.go
+++ b/internal/service/login/login_test.go
@@ -20,6 +20,11 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+var accountColumns = []string{
+	"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
+	"last_seen_at", "status", "auth_source", "created_at", "updated_at",
+}
+
 func TestService_Login(t *testing.T) {
 	accountID := uuid.New()
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password123"), 12)
@@ -38,13 +43,10 @@ func TestService_Login(t *testing.T) {
 				Password: "password123",
 			},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				rows := pgxmock.NewRows([]string{
-					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
-				}).AddRow(
+				rows := pgxmock.NewRows(accountColumns).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -76,13 +78,10 @@ func TestService_Login(t *testing.T) {
 				Password: "wrongpassword",
 			},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				rows := pgxmock.NewRows([]string{
-					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
-				}).AddRow(
+				rows := pgxmock.NewRows(accountColumns).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -97,13 +96,10 @@ func TestService_Login(t *testing.T) {
 				Password: "password123",
 			},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				rows := pgxmock.NewRows([]string{
-					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
-				}).AddRow(
+				rows := pgxmock.NewRows(accountColumns).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("testuser").
@@ -122,13 +118,10 @@ func TestService_Login(t *testing.T) {
 				Password: "password123",
 			},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				rows := pgxmock.NewRows([]string{
-					"id", "username", "email", "name", "password", "is_admin", "language", "theme", "timezone",
-					"last_seen_at", "status", "created_at", "updated_at",
-				}).AddRow(
+				rows := pgxmock.NewRows(accountColumns).AddRow(
 					accountID, "testuser", "test@example.com", stringPtr("Test User"),
 					string(hashedPassword), false, stringPtr("en"), stringPtr("light"),
-					stringPtr("UTC"), nil, "active", now, now,
+					stringPtr("UTC"), nil, "active", "local", now, now,
 				)
 				mock.ExpectQuery(`SELECT .+ FROM account WHERE \(email = \$1 OR username = \$1\) AND status = 'active'`).
 					WithArgs("test@example.com").
@@ -151,7 +144,7 @@ func TestService_Login(t *testing.T) {
 
 			db := &database.DB{Pool: mock}
 			accountSvc := account.NewService(db)
-			s := NewService(db, accountSvc)
+			s := NewService(db, accountSvc, nil)
 
 			acc, err := s.Login(context.Background(), tt.req)
 			if tt.wantErr != nil {

--- a/migrations/00003_add_auth_source_to_account.sql
+++ b/migrations/00003_add_auth_source_to_account.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE account ADD COLUMN auth_source TEXT NOT NULL DEFAULT 'local';
+
+-- +goose Down
+ALTER TABLE account DROP COLUMN auth_source;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -28,6 +28,7 @@ export type User = {
   timezone?: string;
   lastSeenAt?: string;
   status: string;
+  authSource: string;
   isDisabled: boolean;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Adds LDAP as an authentication provider with fallback to local auth.
When enabled, login attempts LDAP first, then falls back to local
password authentication. LDAP users can be auto-provisioned on first
login or require pre-created accounts, controlled via LDAP_AUTO_PROVISION.

Key changes:
- New LDAP service (internal/service/ldap/) using go-ldap/ldap/v3
- LDAP config via environment variables (LDAP_ENABLED, LDAP_HOST, etc.)
- Login service updated to try LDAP then local auth
- Account model gains auth_source column (migration 00003)
- GetOrCreateLDAPAccount for auto-provisioning LDAP users
- All existing tests updated for new auth_source field

https://claude.ai/code/session_01CKe6kKnnvS83saNT4JrTmW